### PR TITLE
Added support backing up and restoring of saved values.

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base32"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/99designs/keyring"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/pbkdf2"
+	"io"
+	"strconv"
+	"strings"
+)
+
+type backup struct {
+	Name     string `json:"name"`
+	Digits   string `json:"digits"`
+	Interval string `json:"interval"`
+	Secret   string `json:"secret"`
+}
+
+func backupAllKeys(storage Storage, password string) (string, error) {
+	ring, err := openKeyring()
+	if err != nil {
+		return "", err
+	}
+
+	keys, err := storage.ListKey()
+	if err != nil {
+		return "", err
+	}
+
+	allKeys := make([]string, 0)
+
+	for _, v := range keys {
+		value, err := backupKeyFromRing(storage, ring, v, password)
+		if err != nil {
+			return "", err
+		}
+		allKeys = append(allKeys, value)
+	}
+
+	return strings.Join(allKeys, "."), nil
+}
+
+func restore(storage Storage, input string, password string) error {
+	sections := strings.Split(input, ".")
+
+	for _, section := range sections {
+		b, err := decryptBackup(section, password)
+		if err != nil {
+			return err
+		}
+
+		var digits interface{}
+		if b.Digits != "" {
+			digits = b.Digits
+		}
+
+		var interval interface{}
+		if b.Interval != "" {
+			interval = b.Interval
+		}
+
+		err = add(storage, b.Name, b.Secret, digits, interval)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func backupKeyFromRing(storage Storage, ring keyring.Keyring, keyName string, password string) (string, error) {
+	debugPrint(fmt.Sprintf("Retrieving and encrypting key '%v' for backup", keyName))
+
+	key := KeyFromStorage(storage, ring, keyName)
+
+	rawSecret, err := key.secret.Value()
+	if err != nil {
+		return "", err
+	}
+
+	secret := base32.StdEncoding.EncodeToString(rawSecret)
+
+	b := backup{
+		Name:     key.Name,
+		Digits:   strconv.Itoa(key.Digits),
+		Interval: strconv.Itoa(key.Interval),
+		Secret:   secret,
+	}
+
+	return encryptBackup(b, password)
+}
+
+func encryptBackup(value backup, password string) (string, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+
+	c, err := aes.NewCipher(deriveKey(password))
+	if err != nil {
+		return "", err
+	}
+
+	gcm, err := cipher.NewGCM(c)
+	if err != nil {
+		return "", err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+
+	sealed := gcm.Seal(nonce, nonce, encoded, nil)
+	return base64.StdEncoding.EncodeToString(sealed), nil
+}
+
+func decryptBackup(value string, password string) (backup, error) {
+	decoded, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return backup{}, err
+	}
+
+	c, err := aes.NewCipher(deriveKey(password))
+	if err != nil {
+		return backup{}, err
+	}
+
+	gcm, err := cipher.NewGCM(c)
+	if err != nil {
+		return backup{}, err
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(decoded) < nonceSize {
+		return backup{}, errors.New("invalid nonce size, cannot decrypt supplied value")
+	}
+
+	nonce, ciphertext := decoded[:nonceSize], decoded[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return backup{}, err
+	}
+
+	b := backup{}
+	if err := json.Unmarshal(plaintext, &b); err != nil {
+		return backup{}, err
+	}
+
+	return b, nil
+}
+
+func deriveKey(passphrase string) []byte {
+	return pbkdf2.Key([]byte(passphrase), nil, 1000, 32, sha256.New)
+}


### PR DESCRIPTION
Saved backups are AES encrypted, each key encrypted individually for easier (de)serialisation. New commands are restore <file-path> and backup <file-path> with a password then prompted for both commands.

Been running 2ami on my work laptop and needed to migrate the keys, noticed you had a couple issues open for restore and backup ( #14 and #13). Hope the changes are of some use.