### PR TITLE
update runners to latest OS versions

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -11,7 +11,7 @@ jobs:
   nightly:
     strategy:
       matrix:
-        operating-system: [ubuntu-20.04, windows-2019, macos-11]
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -34,7 +34,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        operating-system: [ubuntu-20.04, windows-2019, macos-11]
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Disable EOL conversions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   create-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-        operating-system: [ubuntu-20.04, windows-2019, macos-11]
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Update runners to use latest OS instead of pinned ones, that are no longer available.
