### PR TITLE
add support for aegis format on restore

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -16,10 +16,13 @@ import (
 	"github.com/99designs/keyring"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/pbkdf2"
+
+	"github.com/endorama/2ami/internal/aegis"
 )
 
 const (
-	backupFormat2ami = "2ami"
+	backupFormat2ami  = "2ami"
+	backupFormatAegis = "aegis"
 )
 
 type backup struct {
@@ -57,6 +60,8 @@ func restore(storage Storage, input string, password string, format string) erro
 	switch format {
 	case backupFormat2ami:
 		return restore2ami(storage, input, password)
+	case backupFormatAegis:
+		return restoreAegis(storage, input, password)
 	default:
 		return fmt.Errorf("unsupported backup format: %s", format)
 	}
@@ -85,6 +90,93 @@ func restore2ami(storage Storage, input string, password string) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func restoreAegis(storage Storage, input string, password string) error {
+	// Parse the Aegis backup
+	backup, err := aegis.ParseBackup([]byte(input))
+	if err != nil {
+		return fmt.Errorf("failed to parse Aegis backup: %w", err)
+	}
+
+	var db *aegis.DB
+
+	// Check if the backup is encrypted
+	if backup.IsEncrypted() {
+		// Decrypt the backup
+		db, err = backup.DecryptBackup(password)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt Aegis backup: %w", err)
+		}
+	} else {
+		// Parse plain text backup
+		db, err = backup.ParsePlainBackup()
+		if err != nil {
+			return fmt.Errorf("failed to parse plain Aegis backup: %w", err)
+		}
+	}
+
+	// Import the entries
+	return importAegisEntries(storage, db.Entries)
+}
+
+func importAegisEntries(storage Storage, entries []aegis.Entry) error {
+	for _, entry := range entries {
+		// Extract secret from info
+		secretInterface, ok := entry.Info["secret"]
+		if !ok {
+			debugPrint(fmt.Sprintf("Skipping entry '%s' - no secret found", entry.Name))
+			continue
+		}
+
+		secret, ok := secretInterface.(string)
+		if !ok {
+			debugPrint(fmt.Sprintf("Skipping entry '%s' - invalid secret type", entry.Name))
+			continue
+		}
+
+		// Validate the secret is base32
+		if err := isValidBase32(secret); err != nil {
+			debugPrint(fmt.Sprintf("Skipping entry '%s' - invalid base32 secret: %v", entry.Name, err))
+			continue
+		}
+
+		// Determine entry name (use issuer + name if available)
+		entryName := entry.Name
+		if entry.Issuer != "" {
+			entryName = entry.Issuer + " - " + entry.Name
+		}
+
+		// Extract digits
+		var digits interface{}
+		if digitsInterface, ok := entry.Info["digits"]; ok {
+			if digitsFloat, ok := digitsInterface.(float64); ok {
+				digits = int(digitsFloat)
+			}
+		}
+
+		// Extract interval/period
+		var interval interface{}
+		if entry.Type == "totp" {
+			if periodInterface, ok := entry.Info["period"]; ok {
+				if periodFloat, ok := periodInterface.(float64); ok {
+					interval = int(periodFloat)
+				}
+			}
+		}
+
+		// Add the entry
+		debugPrint(fmt.Sprintf("Adding entry: %s, %s, %s, %s", entryName, secret, digits, interval))
+		err := add(storage, entryName, secret, digits, interval)
+		if err != nil {
+			debugPrint(fmt.Sprintf("Failed to add entry '%s': %v", entryName, err))
+			continue
+		}
+
+		debugPrint(fmt.Sprintf("Successfully imported entry: %s", entryName))
 	}
 
 	return nil

--- a/internal/aegis/aegis.go
+++ b/internal/aegis/aegis.go
@@ -1,0 +1,333 @@
+// Package aegis provides functionality to parse and decrypt Aegis Authenticator backup files.
+//
+// Aegis Authenticator is a free, secure and open source 2FA app for Android that supports
+// HOTP and TOTP algorithms. This package implements the Aegis backup format specification
+// to allow importing 2FA secrets from Aegis backups into other applications.
+//
+// # Supported Backup Formats
+//
+// The package supports both encrypted and plain text Aegis backup formats:
+//
+//   - **Encrypted Backups**: Password-protected backups using AES-256-GCM encryption
+//     with scrypt key derivation (N=32768, r=8, p=1)
+//   - **Plain Text Backups**: Unencrypted JSON backups for easy import/export
+//
+// # Supported Entry Types
+//
+// The package can handle the following OTP entry types from Aegis backups:
+//
+//   - **TOTP**: Time-based One-Time Password (RFC 6238)
+//   - **HOTP**: HMAC-based One-Time Password (RFC 4226)
+//   - **Steam**: Steam Guard authenticator tokens
+//
+// # Usage Example
+//
+//	// Parse an Aegis backup file
+//	data, err := os.ReadFile("aegis_backup.json")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	backup, err := aegis.ParseBackup(data)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	var db *aegis.DB
+//	if backup.IsEncrypted() {
+//	    // Decrypt encrypted backup
+//	    db, err = backup.DecryptBackup("your_password")
+//	    if err != nil {
+//	        log.Fatal(err)
+//	    }
+//	} else {
+//	    // Parse plain text backup
+//	    db, err = backup.ParsePlainBackup()
+//	    if err != nil {
+//	        log.Fatal(err)
+//	    }
+//	}
+//
+//	// Process the entries
+//	for _, entry := range db.Entries {
+//	    secret := entry.Info["secret"].(string)
+//	    fmt.Printf("Entry: %s (%s) - Secret: %s\n", entry.Name, entry.Issuer, secret)
+//	}
+//
+// # Security Considerations
+//
+// - The package uses the same cryptographic primitives as Aegis Authenticator
+// - Scrypt parameters are fixed to match Aegis implementation (N=32768, r=8, p=1)
+// - AES-256-GCM is used for authenticated encryption
+// - All cryptographic operations are performed in memory
+//
+// # Aegis Backup Format
+//
+// Aegis backups are stored in JSON format with the following structure:
+//
+//	{
+//	    "version": 1,
+//	    "header": {
+//	        "slots": [...],     // Encryption slots (null for plain text)
+//	        "params": {...}     // Encryption parameters (null for plain text)
+//	    },
+//	    "db": "..."            // Encrypted base64 string or plain JSON object
+//	}
+//
+// For more information about the Aegis backup format, see:
+// https://github.com/beemdevelopment/Aegis/blob/master/docs/vault.md
+package aegis
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"golang.org/x/crypto/scrypt"
+)
+
+// Backup represents the top-level Aegis backup structure
+type Backup struct {
+	Version int         `json:"version"`
+	Header  Header      `json:"header"`
+	DB      interface{} `json:"db"` // Can be string (encrypted) or object (plain)
+}
+
+// Header contains the encryption slots and parameters
+type Header struct {
+	Slots  []Slot `json:"slots"`
+	Params Params `json:"params"`
+}
+
+// Slot represents an encryption slot (password, biometric, etc.)
+type Slot struct {
+	Type      int    `json:"type"`
+	UUID      string `json:"uuid"`
+	Key       string `json:"key"`
+	KeyParams Params `json:"key_params"`
+	N         int    `json:"n,omitempty"`    // scrypt parameter
+	R         int    `json:"r,omitempty"`    // scrypt parameter
+	P         int    `json:"p,omitempty"`    // scrypt parameter
+	Salt      string `json:"salt,omitempty"` // scrypt salt
+}
+
+// Params contains encryption parameters (nonce and tag)
+type Params struct {
+	Nonce string `json:"nonce"`
+	Tag   string `json:"tag"`
+}
+
+// DB represents the decrypted database content
+type DB struct {
+	Version int     `json:"version"`
+	Entries []Entry `json:"entries"`
+	Groups  []Group `json:"groups"`
+}
+
+// Entry represents a single TOTP/HOTP entry
+type Entry struct {
+	Type     string                 `json:"type"`
+	UUID     string                 `json:"uuid"`
+	Name     string                 `json:"name"`
+	Issuer   string                 `json:"issuer"`
+	Note     string                 `json:"note,omitempty"`
+	Icon     interface{}            `json:"icon"`
+	IconMime interface{}            `json:"icon_mime"`
+	IconHash interface{}            `json:"icon_hash"`
+	Favorite bool                   `json:"favorite"`
+	Info     map[string]interface{} `json:"info"`
+	Groups   []string               `json:"groups"`
+}
+
+// Group represents a group of entries
+type Group struct {
+	UUID string `json:"uuid"`
+	Name string `json:"name"`
+}
+
+// ParseBackup parses an Aegis backup from JSON
+func ParseBackup(data []byte) (*Backup, error) {
+	var backup Backup
+	if err := json.Unmarshal(data, &backup); err != nil {
+		return nil, fmt.Errorf("failed to parse Aegis backup JSON: %w", err)
+	}
+	return &backup, nil
+}
+
+// IsEncrypted checks if the backup is encrypted
+func (b *Backup) IsEncrypted() bool {
+	return b.Header.Slots != nil && len(b.Header.Slots) > 0
+}
+
+// DecryptBackup decrypts an encrypted Aegis backup
+func (b *Backup) DecryptBackup(password string) (*DB, error) {
+	if !b.IsEncrypted() {
+		return nil, fmt.Errorf("backup is not encrypted")
+	}
+
+	// Find a password slot (type 1)
+	var passwordSlot *Slot
+	for i := range b.Header.Slots {
+		if b.Header.Slots[i].Type == 1 { // Password slot
+			passwordSlot = &b.Header.Slots[i]
+			break
+		}
+	}
+
+	if passwordSlot == nil {
+		return nil, fmt.Errorf("no password slot found in Aegis backup")
+	}
+
+	// Derive key using scrypt
+	key, err := deriveKey(password, passwordSlot.Salt, passwordSlot.N, passwordSlot.R, passwordSlot.P)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive key: %w", err)
+	}
+
+	// Decrypt the master key from the slot
+	masterKey, err := decryptSlot(key, passwordSlot.Key, passwordSlot.KeyParams.Nonce, passwordSlot.KeyParams.Tag)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt master key: %w", err)
+	}
+
+	// Decrypt the database content
+	dbString, ok := b.DB.(string)
+	if !ok {
+		return nil, fmt.Errorf("encrypted database should be a string")
+	}
+
+	decryptedDB, err := decryptDB(masterKey, dbString, b.Header.Params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt database: %w", err)
+	}
+
+	// Parse the decrypted database
+	var db DB
+	if err := json.Unmarshal(decryptedDB, &db); err != nil {
+		return nil, fmt.Errorf("failed to parse decrypted database: %w", err)
+	}
+
+	return &db, nil
+}
+
+// ParsePlainBackup parses a plain text Aegis backup
+func (b *Backup) ParsePlainBackup() (*DB, error) {
+	if b.IsEncrypted() {
+		return nil, fmt.Errorf("backup is encrypted, use DecryptBackup instead")
+	}
+
+	// For plain text backups, the DB field should be an object
+	dbBytes, err := json.Marshal(b.DB)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal plain database: %w", err)
+	}
+
+	var db DB
+	if err := json.Unmarshal(dbBytes, &db); err != nil {
+		return nil, fmt.Errorf("failed to parse plain database: %w", err)
+	}
+
+	return &db, nil
+}
+
+// deriveKey derives a key using scrypt with Aegis parameters
+func deriveKey(password, salt string, n, r, p int) ([]byte, error) {
+	saltBytes, err := hex.DecodeString(salt)
+	if err != nil {
+		return nil, fmt.Errorf("invalid salt: %w", err)
+	}
+
+	// Use scrypt with Aegis parameters
+	key, err := scrypt.Key([]byte(password), saltBytes, n, r, p, 32)
+	if err != nil {
+		return nil, fmt.Errorf("scrypt failed: %w", err)
+	}
+
+	return key, nil
+}
+
+// decryptSlot decrypts a slot using AES-GCM
+func decryptSlot(key []byte, encryptedKey, nonce, tag string) ([]byte, error) {
+	// Decode the encrypted key and parameters
+	encryptedBytes, err := hex.DecodeString(encryptedKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid encrypted key: %w", err)
+	}
+
+	nonceBytes, err := hex.DecodeString(nonce)
+	if err != nil {
+		return nil, fmt.Errorf("invalid nonce: %w", err)
+	}
+
+	tagBytes, err := hex.DecodeString(tag)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tag: %w", err)
+	}
+
+	// Create AES-GCM cipher
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	// Combine ciphertext and tag (tag is appended, not prepended)
+	ciphertext := append(encryptedBytes, tagBytes...)
+
+	// Decrypt
+	plaintext, err := gcm.Open(nil, nonceBytes, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decryption failed: %w", err)
+	}
+
+	return plaintext, nil
+}
+
+// decryptDB decrypts the database content using AES-GCM
+func decryptDB(masterKey []byte, encryptedDB string, params Params) ([]byte, error) {
+	// Decode the encrypted database
+	encryptedBytes, err := base64.StdEncoding.DecodeString(encryptedDB)
+	if err != nil {
+		return nil, fmt.Errorf("invalid encrypted database: %w", err)
+	}
+
+	// Decode parameters
+	nonceBytes, err := hex.DecodeString(params.Nonce)
+	if err != nil {
+		return nil, fmt.Errorf("invalid nonce: %w", err)
+	}
+
+	tagBytes, err := hex.DecodeString(params.Tag)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tag: %w", err)
+	}
+
+	// Create AES-GCM cipher
+	block, err := aes.NewCipher(masterKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	// Combine ciphertext and tag (tag is appended, not prepended)
+	ciphertext := append(encryptedBytes, tagBytes...)
+
+	// Decrypt
+	plaintext, err := gcm.Open(nil, nonceBytes, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decryption failed: %w", err)
+	}
+
+	return plaintext, nil
+}

--- a/internal/aegis/aegis_test.go
+++ b/internal/aegis/aegis_test.go
@@ -1,0 +1,487 @@
+package aegis
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestParseBackup(t *testing.T) {
+	// Test data from Aegis documentation
+	testData := `{
+		"version": 1,
+		"header": {
+			"slots": null,
+			"params": null
+		},
+		"db": {
+			"version": 1,
+			"entries": [
+				{
+					"type": "totp",
+					"uuid": "3ae6f1ad-2e65-4ed2-a953-1ec0dff2386d",
+					"name": "TestUser",
+					"issuer": "TestService",
+					"note": "Test entry",
+					"icon": null,
+					"icon_mime": null,
+					"icon_hash": null,
+					"favorite": false,
+					"info": {
+						"secret": "JBSWY3DPEHPK3PXP",
+						"algo": "SHA1",
+						"digits": 6,
+						"period": 30
+					},
+					"groups": []
+				}
+			],
+			"groups": []
+		}
+	}`
+
+	backup, err := ParseBackup([]byte(testData))
+	if err != nil {
+		t.Fatalf("Failed to parse Aegis backup: %v", err)
+	}
+
+	// Verify the structure
+	if backup.Version != 1 {
+		t.Errorf("Expected version 1, got %d", backup.Version)
+	}
+
+	if backup.IsEncrypted() {
+		t.Error("Expected backup to not be encrypted")
+	}
+}
+
+func TestIsEncrypted(t *testing.T) {
+	// Test plain backup
+	plainBackup := &Backup{
+		Version: 1,
+		Header: Header{
+			Slots:  nil,
+			Params: Params{},
+		},
+	}
+
+	if plainBackup.IsEncrypted() {
+		t.Error("Plain backup should not be marked as encrypted")
+	}
+
+	// Test encrypted backup
+	encryptedBackup := &Backup{
+		Version: 1,
+		Header: Header{
+			Slots: []Slot{
+				{
+					Type: 1,
+					UUID: "test-uuid",
+				},
+			},
+			Params: Params{},
+		},
+	}
+
+	if !encryptedBackup.IsEncrypted() {
+		t.Error("Encrypted backup should be marked as encrypted")
+	}
+}
+
+func TestParsePlainBackup(t *testing.T) {
+	// Test data
+	testData := `{
+		"version": 1,
+		"header": {
+			"slots": null,
+			"params": null
+		},
+		"db": {
+			"version": 1,
+			"entries": [
+				{
+					"type": "totp",
+					"uuid": "3ae6f1ad-2e65-4ed2-a953-1ec0dff2386d",
+					"name": "TestUser",
+					"issuer": "TestService",
+					"note": "Test entry",
+					"icon": null,
+					"icon_mime": null,
+					"icon_hash": null,
+					"favorite": false,
+					"info": {
+						"secret": "JBSWY3DPEHPK3PXP",
+						"algo": "SHA1",
+						"digits": 6,
+						"period": 30
+					},
+					"groups": []
+				}
+			],
+			"groups": []
+		}
+	}`
+
+	backup, err := ParseBackup([]byte(testData))
+	if err != nil {
+		t.Fatalf("Failed to parse backup: %v", err)
+	}
+
+	db, err := backup.ParsePlainBackup()
+	if err != nil {
+		t.Fatalf("Failed to parse plain backup: %v", err)
+	}
+
+	// Verify the database structure
+	if db.Version != 1 {
+		t.Errorf("Expected DB version 1, got %d", db.Version)
+	}
+
+	if len(db.Entries) != 1 {
+		t.Errorf("Expected 1 entry, got %d", len(db.Entries))
+	}
+
+	entry := db.Entries[0]
+	if entry.Name != "TestUser" {
+		t.Errorf("Expected name 'TestUser', got '%s'", entry.Name)
+	}
+
+	if entry.Issuer != "TestService" {
+		t.Errorf("Expected issuer 'TestService', got '%s'", entry.Issuer)
+	}
+
+	if entry.Type != "totp" {
+		t.Errorf("Expected type 'totp', got '%s'", entry.Type)
+	}
+
+	// Verify the secret
+	secret, ok := entry.Info["secret"].(string)
+	if !ok {
+		t.Fatal("Secret not found or not a string")
+	}
+
+	if secret != "JBSWY3DPEHPK3PXP" {
+		t.Errorf("Expected secret 'JBSWY3DPEHPK3PXP', got '%s'", secret)
+	}
+
+	// Verify digits
+	digits, ok := entry.Info["digits"].(float64)
+	if !ok {
+		t.Fatal("Digits not found or not a number")
+	}
+
+	if digits != 6 {
+		t.Errorf("Expected digits 6, got %f", digits)
+	}
+
+	// Verify period
+	period, ok := entry.Info["period"].(float64)
+	if !ok {
+		t.Fatal("Period not found or not a number")
+	}
+
+	if period != 30 {
+		t.Errorf("Expected period 30, got %f", period)
+	}
+}
+
+func TestParsePlainBackupEncrypted(t *testing.T) {
+	// Create an encrypted backup
+	encryptedBackup := &Backup{
+		Version: 1,
+		Header: Header{
+			Slots: []Slot{
+				{
+					Type: 1,
+					UUID: "test-uuid",
+				},
+			},
+			Params: Params{},
+		},
+	}
+
+	// Try to parse as plain backup
+	_, err := encryptedBackup.ParsePlainBackup()
+	if err == nil {
+		t.Error("Expected error when parsing encrypted backup as plain")
+	}
+}
+
+func TestDecryptBackupPlain(t *testing.T) {
+	// Create a plain backup
+	plainBackup := &Backup{
+		Version: 1,
+		Header: Header{
+			Slots:  nil,
+			Params: Params{},
+		},
+	}
+
+	// Try to decrypt plain backup
+	_, err := plainBackup.DecryptBackup("password")
+	if err == nil {
+		t.Error("Expected error when decrypting plain backup")
+	}
+}
+
+func TestDeriveKey(t *testing.T) {
+	password := "testpassword"
+	salt := "27ea9ae53fa2f08a8dcd201615a8229422647b3058f9f36b08f9457e62888be1"
+	n := 32768
+	r := 8
+	p := 1
+
+	key, err := deriveKey(password, salt, n, r, p)
+	if err != nil {
+		t.Fatalf("Failed to derive key: %v", err)
+	}
+
+	if len(key) != 32 {
+		t.Errorf("Expected key length 32, got %d", len(key))
+	}
+}
+
+func TestDeriveKeyInvalidSalt(t *testing.T) {
+	password := "testpassword"
+	invalidSalt := "invalid-hex"
+	n := 32768
+	r := 8
+	p := 1
+
+	_, err := deriveKey(password, invalidSalt, n, r, p)
+	if err == nil {
+		t.Error("Expected error with invalid salt")
+	}
+}
+
+func TestDecryptSlotInvalidKey(t *testing.T) {
+	key := []byte("test-key-32-bytes-long-key-here")
+	invalidEncryptedKey := "invalid-hex"
+	nonce := "e9705513ba4951fa7a0608d2"
+	tag := "931237af257b83c693ddb8f9a7eddaf0"
+
+	_, err := decryptSlot(key, invalidEncryptedKey, nonce, tag)
+	if err == nil {
+		t.Error("Expected error with invalid encrypted key")
+	}
+}
+
+func TestDecryptSlotInvalidNonce(t *testing.T) {
+	key := []byte("test-key-32-bytes-long-key-here")
+	encryptedKey := "491d44550430ba248986b904b8cffd3a6c5755d176ac877bd11b82c934225017"
+	invalidNonce := "invalid-hex"
+	tag := "931237af257b83c693ddb8f9a7eddaf0"
+
+	_, err := decryptSlot(key, encryptedKey, invalidNonce, tag)
+	if err == nil {
+		t.Error("Expected error with invalid nonce")
+	}
+}
+
+func TestDecryptDBInvalidDatabase(t *testing.T) {
+	masterKey := []byte("test-key-32-bytes-long-key-here")
+	invalidEncryptedDB := "invalid-base64"
+	params := Params{
+		Nonce: "e9705513ba4951fa7a0608d2",
+		Tag:   "931237af257b83c693ddb8f9a7eddaf0",
+	}
+
+	_, err := decryptDB(masterKey, invalidEncryptedDB, params)
+	if err == nil {
+		t.Error("Expected error with invalid encrypted database")
+	}
+}
+
+func TestDecryptDBInvalidNonce(t *testing.T) {
+	masterKey := []byte("test-key-32-bytes-long-key-here")
+	encryptedDB := "dGVzdA==" // base64 encoded "test"
+	params := Params{
+		Nonce: "invalid-hex",
+		Tag:   "931237af257b83c693ddb8f9a7eddaf0",
+	}
+
+	_, err := decryptDB(masterKey, encryptedDB, params)
+	if err == nil {
+		t.Error("Expected error with invalid nonce")
+	}
+}
+
+// Test with official Aegis test files
+
+func TestOfficialPlainBackup(t *testing.T) {
+	// Read the official plain backup file
+	data, err := os.ReadFile("testdata/aegis_plain.json")
+	if err != nil {
+		t.Skipf("Skipping test - could not read test file: %v", err)
+	}
+
+	backup, err := ParseBackup(data)
+	if err != nil {
+		t.Fatalf("Failed to parse official plain backup: %v", err)
+	}
+
+	if backup.IsEncrypted() {
+		t.Error("Official plain backup should not be marked as encrypted")
+	}
+
+	db, err := backup.ParsePlainBackup()
+	if err != nil {
+		t.Fatalf("Failed to parse official plain backup: %v", err)
+	}
+
+	// Verify the structure
+	if db.Version != 1 {
+		t.Errorf("Expected DB version 1, got %d", db.Version)
+	}
+
+	// The official test file has 7 entries
+	if len(db.Entries) != 7 {
+		t.Errorf("Expected 7 entries, got %d", len(db.Entries))
+	}
+
+	// Verify specific entries
+	expectedEntries := []struct {
+		name   string
+		issuer string
+		type_  string
+		secret string
+	}{
+		{"Mason", "Deno", "totp", "4SJHB4GSD43FZBAI7C2HLRJGPQ"},
+		{"James", "SPDX", "totp", "5OM4WOOGPLQEF6UGN3CPEOOLWU"},
+		{"Elijah", "Airbnb", "totp", "7ELGJSGXNCCTV3O6LKJWYFV2RA"},
+		{"James", "Issuu", "hotp", "YOOMIXWS5GN6RTBPUFFWKTW5M4"},
+		{"Benjamin", "Air Canada", "hotp", "KUVJJOM753IHTNDSZVCNKL7GII"},
+		{"Mason", "WWE", "hotp", "5VAML3X35THCEBVRLV24CGBKOY"},
+		{"Sophia", "Boeing", "steam", "JRZCL47CMXVOQMNPZR2F7J4RGI"},
+	}
+
+	for i, expected := range expectedEntries {
+		if i >= len(db.Entries) {
+			t.Errorf("Entry %d not found", i)
+			continue
+		}
+
+		entry := db.Entries[i]
+		if entry.Name != expected.name {
+			t.Errorf("Entry %d: expected name '%s', got '%s'", i, expected.name, entry.Name)
+		}
+		if entry.Issuer != expected.issuer {
+			t.Errorf("Entry %d: expected issuer '%s', got '%s'", i, expected.issuer, entry.Issuer)
+		}
+		if entry.Type != expected.type_ {
+			t.Errorf("Entry %d: expected type '%s', got '%s'", i, expected.type_, entry.Type)
+		}
+
+		secret, ok := entry.Info["secret"].(string)
+		if !ok {
+			t.Errorf("Entry %d: secret not found or not a string", i)
+			continue
+		}
+		if secret != expected.secret {
+			t.Errorf("Entry %d: expected secret '%s', got '%s'", i, expected.secret, secret)
+		}
+	}
+}
+
+func TestOfficialEncryptedBackup(t *testing.T) {
+	// Read the official encrypted backup file
+	data, err := os.ReadFile("testdata/aegis_encrypted.json")
+	if err != nil {
+		t.Skipf("Skipping test - could not read test file: %v", err)
+	}
+
+	backup, err := ParseBackup(data)
+	if err != nil {
+		t.Fatalf("Failed to parse official encrypted backup: %v", err)
+	}
+
+	if !backup.IsEncrypted() {
+		t.Error("Official encrypted backup should be marked as encrypted")
+	}
+
+	// The password for the test file is "test" (from the decrypt.py script)
+	db, err := backup.DecryptBackup("test")
+	if err != nil {
+		t.Fatalf("Failed to decrypt official encrypted backup: %v", err)
+	}
+
+	// Verify the structure
+	if db.Version != 1 {
+		t.Errorf("Expected DB version 1, got %d", db.Version)
+	}
+
+	// The encrypted backup should contain the same entries as the plain one
+	if len(db.Entries) != 7 {
+		t.Errorf("Expected 7 entries, got %d", len(db.Entries))
+	}
+
+	// Verify that we can extract secrets from the decrypted entries
+	for i, entry := range db.Entries {
+		secret, ok := entry.Info["secret"].(string)
+		if !ok {
+			t.Errorf("Entry %d: secret not found or not a string", i)
+			continue
+		}
+		if secret == "" {
+			t.Errorf("Entry %d: secret is empty", i)
+		}
+	}
+}
+
+func TestOfficialEncryptedBackupWrongPassword(t *testing.T) {
+	// Read the official encrypted backup file
+	data, err := os.ReadFile("testdata/aegis_encrypted.json")
+	if err != nil {
+		t.Skipf("Skipping test - could not read test file: %v", err)
+	}
+
+	backup, err := ParseBackup(data)
+	if err != nil {
+		t.Fatalf("Failed to parse official encrypted backup: %v", err)
+	}
+
+	// Try with wrong password
+	_, err = backup.DecryptBackup("wrongpassword")
+	if err == nil {
+		t.Error("Expected error when using wrong password")
+	}
+}
+
+func TestOfficialBackupRoundTrip(t *testing.T) {
+	// Read the official plain backup file
+	data, err := os.ReadFile("testdata/aegis_plain.json")
+	if err != nil {
+		t.Skipf("Skipping test - could not read test file: %v", err)
+	}
+
+	backup, err := ParseBackup(data)
+	if err != nil {
+		t.Fatalf("Failed to parse official plain backup: %v", err)
+	}
+
+	db, err := backup.ParsePlainBackup()
+	if err != nil {
+		t.Fatalf("Failed to parse official plain backup: %v", err)
+	}
+
+	// Serialize and deserialize to test round trip
+	dbBytes, err := json.Marshal(db)
+	if err != nil {
+		t.Fatalf("Failed to marshal DB: %v", err)
+	}
+
+	var db2 DB
+	err = json.Unmarshal(dbBytes, &db2)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal DB: %v", err)
+	}
+
+	// Verify the round trip preserved the data
+	if db2.Version != db.Version {
+		t.Errorf("Version mismatch: expected %d, got %d", db.Version, db2.Version)
+	}
+
+	if len(db2.Entries) != len(db.Entries) {
+		t.Errorf("Entries count mismatch: expected %d, got %d", len(db.Entries), len(db2.Entries))
+	}
+}

--- a/internal/aegis/testdata/aegis_encrypted.json
+++ b/internal/aegis/testdata/aegis_encrypted.json
@@ -1,0 +1,26 @@
+{
+    "version": 1,
+    "header": {
+        "slots": [
+            {
+                "type": 1,
+                "uuid": "a8325752-c1be-458a-9b3e-5e0a8154d9ec",
+                "key": "491d44550430ba248986b904b8cffd3a6c5755d176ac877bd11b82c934225017",
+                "key_params": {
+                    "nonce": "e9705513ba4951fa7a0608d2",
+                    "tag": "931237af257b83c693ddb8f9a7eddaf0"
+                },
+                "n": 32768,
+                "r": 8,
+                "p": 1,
+                "salt": "27ea9ae53fa2f08a8dcd201615a8229422647b3058f9f36b08f9457e62888be1",
+                "repaired": true
+            }
+        ],
+        "params": {
+            "nonce": "095fd13dee336fa56b4634ff",
+            "tag": "5db2470edf2d12f82a89ae7f48ccd50c"
+        }
+    },
+    "db": "RtGfUrZ01nzRnvHjPJGyWjfa6shQ7NYwa491CgAWNBM8OeGZVIHhnDAVlVWNlSoq2V097p5Yq5m+SFl5g9nBBBQBNePQnj6CCvu1NfNtoA6R3hyp77gd+e+O2MRnOGH1Z1laV2Tl6p3q8IUHWgAJ36LbUxiCXmfh7bWm198uA4bgLwrEmo04MrqeYXggLuXrJrp6dUJQFD72dgoPbHijlSycY5GLel3ZbAXRsUHszd+xdywpj7\/TYa4OYFel0M0QcCpsKA1LRQz365X9OXPJdTsmVyR4dJ6x5RIVeh39lAYKUf7T4w7BLC8taST5m4J\/VXDueKbvg8R13bNWF0aRHUgeuI9BNzMZINJlzKFKNRknTaJ\/1kEUU0sLkgcaVkX\/DVTGG+pWi5MHijicrK0i4LHN3CUwV2\/\/ZNJCGXM5ErsKMOnJfma52gMdifPiXU317Klvc5oOZFYGnhbhJ2WtPIuqjdvnfuLat2JxA7Xx3LqquRWGL2113yjzVzGBDCVY6iIdedBEgH8CGD826\/3R3m6dR5sfSggQ2SbtQA\/DZNhLSNSU+bfNScVQvUWfR2Lf7Q\/4FR\/xATAQJ9IIBeL+w2ErLUPjURocFXup5YOBHxFdDjZ2FqhbAq4h3Zn\/BJ57xUcYEA+YtP5uOP2lQwUh\/0vFWizDVotzraO8tZiBZBsODyb69eJrXNwFbIjeUczY6wrJs1+676IilbCsmtoYvWEpUZF4hIi7TYAD+nyXX\/olrkog9omWZk8R7hJ9KRDfckXEc\/XSzWhk3Kmfa7pRNh9wYZsaR7VPZGZebQMuUKfRRci2qMsZOJvQsDBJvVze0xW9SqiySDgGyRX\/DwzuaZEGZZriaLf6ox7LwY2Qi6QpYOYbAaEaXAesCR1DPxFfGKsUHVjF8hKA6ZBXDXdqM3Y+14naIOH9S7UzYn32botoVLOykSjnW6z6M0ZPkz3dwowMJiVQcyD7p+9p4J6f1S81pFS7DP+jF+PTyC3c3q\/dwFhNdoG6iV9eQEAxjUi6MpzvFRsk9RsLcQqYgzJGmRjYeXlKH8k8tTu1A4puo6w3Daz8hZz9NafMgMsuqY0oKVLgdNqFz8yVMsxYfBW\/oW56SuQyyVWyxXjXmbk1vpYCTL5kXvIZWoTmBRRDb0ay5S\/dlD6z\/WR45\/C4AwcCE9m4Yf3zisRNa7AqWLVgkmJxFdfJxjiuPtUIK79s+lIJkyRENEqkvm809qIxDhkQzY8zcCt4oXCEbJUfSG4awBs1VvilJIwe6qi0bNtqXtAb5TctgxTh29A9oGlsRG4o8sHqA1mtjp5QiLWp5Hh6rOH95W6+fnBiOW+Iw0evBTduroWvx37HBTktJz79zGe0l3c0Y6VmiFvB7knmT2CrgP7woRkxGbXxdE9zMPQJM9ursD538MVDdD\/0tdkxHxilt47f1DPo2CKUWU8Q1KMm1zLXfVO8BbGUWIv4YeDKHfMUL\/HcStv5VJY+LbnOEjzGT4e1\/avSQmqBL4G9XNkYmyMhC8tlLQcmMMH4bNfPOO3vi5Pb5E7XveSgxlOHs4F0+nqxnFOAu8494MEtx6u5+B7d8LI\/DhEO5zTDwE+THiKej6vCsFxTZ519rm67HycOwRR4LKrwfDeUEK3X1PzryOD5zcv3PMcSBgZ8EWvTfZ9ygKP8BmRQRpydTbSt8Hj5fTUuajADCP0Ggw+6G7n+5FhExJNd+o9D8d4KgLPOe08M8InW7pLB389TWtSo4v3VNjcmmJNQ26wlPkhO\/xBU1URFR0fXU3eCO+w++IMt\/fOSqSpNF9bWElfWHIQ23ntxVke\/hR9j\/GG3tHGxYS5pL42sJF\/Re\/UlUJTGSQP6up2xVYs6gncQ0zACDOPjLQmQzYhz\/hr8S6EjYfK++yLZmRTjEI7xT9u\/B5YLyOQCYVTaF\/pDEegjsehXM3qJBfsA+XY7F9TRsmM\/MSVaPDkdIJ7zvL9xtaF6bXdZoZ6po3ml8uu41pSkNmMKgyEy5E0UQUTWMPLC8drUoQ\/KWQnVIN6HUXGBjYy6aax\/LYZaBcbZi97FHK0h+wsx3WN\/uQozNkQjwGYE8fwYxRYh1RaFi5PkiCM505ib7e82Yuts0l+cBb6nG1IruDplg9BD\/G9w4vVDePEikhcPyY\/p7AZ4i7u\/bL2YKlbE3HyJa+7dkbWJgGidtRZgu+Fdl2T\/rrRJ4+lVaKPVKGKT7ItZdIeitIYUdRxCzrOf1ItZCC8BWa4PElDAjj2yDNmMYRpXJBe3gQHWs\/H5SZgFuwsfCu23uzNRQYib8SuwIJQDvPiXo7m4oIySO8VyvemcExlbXSlbZbvwVxYavTVfcUpAXI6qlsg2jjk+JZahfKrWNC5COZPdVjdAXCoiKU+HBPmEFCwQv\/7zlSBEiI2piyqd+MPwnP63RdGO+oXYid6hn4Nm8kcOhtRyvYm95p66jzGlEugsfxJCED7MTh3XShqa2tt4lFG25icllzTvIJboRkz5oIB4dZVS9+q2TgGUoX7UCpobD8WkHo\/y0cpTuZr8vzXqx2fObxzPNoVgxJmp9E06G2bhMVHPpT17xbfq\/KhJJn7k1S0sfXPG+SmYlX4U7zNSe1M7JXtLf3uVOLz7Ccjp3yvcdq8nRmVym3Zwsz+vv57FA2A0dy3Db97ypJa9HGaxnnYIZHHzep0gJCeeIKE9L32zGCoUg+cPu9B2lPEgIr64iGiuvKSRwNQpOBktM6qqjQntE0Me6mh426irFQ\/3tcfH9a4lZEwwuU1X+lUBUWQp3n5Ej4BSJEs8E6H0EjBvyk69q3qjy5yi7ROVRis6y6S1v4er77RHQUf3phK5354VJHrp9pR926t5qngH5RVF4eljwtXDs3MkejADJ6stBHa\/w7FcbUClO8U+S4Bidxb3mZCiZkUVTpbzvBfYAiQvAfdkMa49o3a5DXKsbXyUPrmr6fWRfM1fS0Ehp0lUv6BDj0yR13CLMpKDU4GfDrl8UEvwh7gwtBRkuaBFzyMtd3NeE7kIGf9vFs6MEl2dmMDFSDid7MdVSDVTlhaAtp+zsRejKW3OQr5n051FzkUsIFGty9AWOkwjZCbstHYCOtyJnsnXP1i9lRDFBgPpFgmDD+bzzg0g9AOAxzqTiLF7bb1jejfe5qVr5V9+7zLpwRLiYaLkNOmpsqvNMuYVwdqTp6nyoougdgBlvve3EG0k09sFKi2Ep9lq+QkS7zGre2jJDrqgdC08+V4PXHYkP3V3Zjgn1x6RfQ2PE+2zvk1GGEgzcNww3byoYw0Ra5qS5yftMy\/2WahbA8fjUYvtmksFH8VjN3yasZt3sdQLWtv8qXxZscy+pCyjTdyxW+ddFnrWuqMIV3jbGMvngq6dL\/n5+DumjbA1gmBJVOpmyEsc1iwHDS36cNnyi1htGFO\/6\/Va4YPYK7dG6LY387UoBUU9Q9ijrBrSGpzPWYmXBLZ8e1MMPfHIN1WsaTgYO9leg3MAJTjQFTFrQ5dguYpWhlm2sWJT45jrda4uWqduB+aQLzYRWhEDBFzPV3ZgIe0SB+7h04Vm0Pu\/LDRvqaolpZ86CEm+zgjBOKeEGFwzTXxH\/5pBoca1bZ6wvsbVZxJNBeH8\/w=="
+}

--- a/internal/aegis/testdata/aegis_plain.json
+++ b/internal/aegis/testdata/aegis_plain.json
@@ -1,0 +1,103 @@
+{
+    "version": 1,
+    "header": {
+        "slots": null,
+        "params": null
+    },
+    "db": {
+        "version": 1,
+        "entries": [
+            {
+                "type": "totp",
+                "uuid": "3ae6f1ad-2e65-4ed2-a953-1ec0dff2386d",
+                "name": "Mason",
+                "issuer": "Deno",
+                "icon": null,
+                "info": {
+                    "secret": "4SJHB4GSD43FZBAI7C2HLRJGPQ",
+                    "algo": "SHA1",
+                    "digits": 6,
+                    "period": 30
+                }
+            },
+            {
+                "type": "totp",
+                "uuid": "84b55971-a3d2-4173-a5bb-0aea113dbc17",
+                "name": "James",
+                "issuer": "SPDX",
+                "icon": null,
+                "info": {
+                    "secret": "5OM4WOOGPLQEF6UGN3CPEOOLWU",
+                    "algo": "SHA256",
+                    "digits": 7,
+                    "period": 20
+                }
+            },
+            {
+                "type": "totp",
+                "uuid": "3deaff2e-f181-4837-80e1-fdf0c54e9363",
+                "name": "Elijah",
+                "issuer": "Airbnb",
+                "icon": null,
+                "info": {
+                    "secret": "7ELGJSGXNCCTV3O6LKJWYFV2RA",
+                    "algo": "SHA512",
+                    "digits": 8,
+                    "period": 50
+                }
+            },
+            {
+                "type": "hotp",
+                "uuid": "0a8c0571-ff6f-4b02-aa4b-50553b4fb4fe",
+                "name": "James",
+                "issuer": "Issuu",
+                "icon": null,
+                "info": {
+                    "secret": "YOOMIXWS5GN6RTBPUFFWKTW5M4",
+                    "algo": "SHA1",
+                    "digits": 6,
+                    "counter": 1
+                }
+            },
+            {
+                "type": "hotp",
+                "uuid": "03e572f2-8ebd-44b0-a57e-e958af74815d",
+                "name": "Benjamin",
+                "issuer": "Air Canada",
+                "icon": null,
+                "info": {
+                    "secret": "KUVJJOM753IHTNDSZVCNKL7GII",
+                    "algo": "SHA256",
+                    "digits": 7,
+                    "counter": 50
+                }
+            },
+            {
+                "type": "hotp",
+                "uuid": "b25f8815-007f-40f7-a700-ce058ac05435",
+                "name": "Mason",
+                "issuer": "WWE",
+                "icon": null,
+                "info": {
+                    "secret": "5VAML3X35THCEBVRLV24CGBKOY",
+                    "algo": "SHA512",
+                    "digits": 8,
+                    "counter": 10300
+                }
+            },
+            {
+                "type": "steam",
+                "uuid": "5b11ae3b-6fc3-4d46-8ca7-cf0aea7de920",
+                "name": "Sophia",
+                "issuer": "Boeing",
+                "icon": null,
+                "info": {
+                    "secret": "JRZCL47CMXVOQMNPZR2F7J4RGI",
+                    "algo": "SHA1",
+                    "digits": 5,
+                    "period": 30
+                }
+            }
+        ]
+    }
+}

--- a/main.go
+++ b/main.go
@@ -296,16 +296,31 @@ func add(storage Storage, name string, secret string, digits interface{}, interv
 	}
 	key := NewKey(ring, name)
 	if digits != nil {
-		key.Digits, err = convertStringToInt(digits.(string))
-		if err != nil {
-			return fmt.Errorf("cannot convert string to int: %w", err)
+		switch v := digits.(type) {
+		case int:
+			key.Digits = v
+		case string:
+			key.Digits, err = convertStringToInt(v)
+			if err != nil {
+				return fmt.Errorf("cannot convert string to int: %w", err)
+			}
+		default:
+			return fmt.Errorf("unsupported type for digits: %T", digits)
 		}
 	}
 	if interval != nil {
-		key.Interval, err = convertStringToInt(interval.(string))
-		if err != nil {
-			return fmt.Errorf("cannot convert string to int: %w", err)
+		switch v := interval.(type) {
+		case int:
+			key.Interval = v
+		case string:
+			key.Interval, err = convertStringToInt(v)
+			if err != nil {
+				return fmt.Errorf("cannot convert string to int: %w", err)
+			}
+		default:
+			return fmt.Errorf("unsupported type for interval: %T", interval)
 		}
+
 	}
 	err = key.Secret(secret)
 	if err != nil {


### PR DESCRIPTION
Add support for restoring backups from [Aegis Authenticator](https://github.com/beemdevelopment/Aegis) format.

To use this format pass `aegis` to `--format` `2ami restore` flag:
```
$ 2ami restore --format aegis path/to/file.json
```
